### PR TITLE
Fix creating url with rules like 'item/<id:\d+>'

### DIFF
--- a/I18nUrlManager.php
+++ b/I18nUrlManager.php
@@ -96,19 +96,14 @@ class I18nUrlManager extends UrlManager
     {
         $params = (array)$params;
 
-        if (array_key_exists($this->languageParam, $params)) {
-            $lang = $params[$this->languageParam];
-            if ((($lang !== Yii::$app->sourceLanguage && ArrayHelper::getValue($this->aliases, $lang) !== Yii::$app->sourceLanguage)
-                    || $this->displaySourceLanguage) && !empty($lang)
-            ) {
-                $params[0] = $lang . '/' . ltrim($params[0], '/');
-            }
-            unset($params[$this->languageParam]);
-        } else {
-            if (Yii::$app->language !== Yii::$app->sourceLanguage || $this->displaySourceLanguage) {
-                $params[0] = static::$currentLanguage . '/' . ltrim($params[0], '/');
-            }
+        $lang = ArrayHelper::remove($params, $this->languageParam, static::$currentLanguage);
+        $sourceLanguage = Yii::$app->sourceLanguage;
+        $locale = ($lang) ? ArrayHelper::getValue($this->aliases, $lang, $lang) : $sourceLanguage;
+
+        if (($lang !== $sourceLanguage && $locale !== $sourceLanguage) || $this->displaySourceLanguage) {
+            return '/' . $lang . '/' . ltrim(parent::createUrl($params), '/');
         }
+
         return parent::createUrl($params);
     }
 }


### PR DESCRIPTION
createUrl works wrong in case when urlManager has rules like this 'item/<id:\d+>'
For example
in urlManager config we have rule
```php
'rules'=>[
    'item/<id:\d+>'=>'/item/view'
],
```
Default language 'en-US', current language 'ru'
```php
Url::to(['/item/view','id'=>1]);
```
returns /ru/item/view?id=1 instead of /ru/item/1

I had to completely change the logic of your method createUrl, but it seems that everything works well. Please tell me if I'm wrong.